### PR TITLE
Upgrade TradeBot: Real-time Order Flow Reactor with Configurable Thresholds and Logging

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,9 @@
+{
+  "buy_threshold": 3,
+  "sell_threshold": 3,
+  "window_seconds": 1.0,
+  "simulation_duration_seconds": 30,
+  "cooldown_seconds": 1.0,
+  "min_trade_interval": 0.1,
+  "max_trade_interval": 0.3
+}

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Core logic package (strategy engine, data processors, etc.)

--- a/core/flow_reactor.py
+++ b/core/flow_reactor.py
@@ -1,0 +1,38 @@
+import time
+from collections import deque
+
+class FlowReactor:
+    def __init__(self, buy_threshold=3, sell_threshold=3, window_seconds=1.0):
+        self.buy_threshold = buy_threshold
+        self.sell_threshold = sell_threshold
+        self.window_seconds = window_seconds
+        self.buy_events = deque()
+        self.sell_events = deque()
+
+    def _prune(self, events):
+        """Remove old events outside the rolling window."""
+        now = time.time()
+        while events and (now - events[0]) > self.window_seconds:
+            events.popleft()
+
+    def register_trade(self, is_buy: bool):
+        """Register a new trade tick."""
+        now = time.time()
+        if is_buy:
+            self.buy_events.append(now)
+            self._prune(self.buy_events)
+        else:
+            self.sell_events.append(now)
+            self._prune(self.sell_events)
+
+    def get_signal(self):
+        """Check if buy/sell pressure has crossed the threshold."""
+        self._prune(self.buy_events)
+        self._prune(self.sell_events)
+
+        if len(self.buy_events) >= self.buy_threshold:
+            return "BUY"
+        elif len(self.sell_events) >= self.sell_threshold:
+            return "SELL"
+        else:
+            return None

--- a/main.py
+++ b/main.py
@@ -1,13 +1,20 @@
 import time
 import random
+import json
 from core.flow_reactor import FlowReactor
 
-def simulate_trade_stream(flow: FlowReactor, duration=10):
-    """
-    Simulate a stream of random buy/sell trades over a fixed duration.
-    Replace this with real websocket data in future steps.
-    """
+def load_config(path="config/config.json"):
+    with open(path, "r") as f:
+        return json.load(f)
+
+def simulate_trade_stream(flow, config):
     start_time = time.time()
+    cooldown = config["cooldown_seconds"]
+    min_interval = config["min_trade_interval"]
+    max_interval = config["max_trade_interval"]
+    duration = config["simulation_duration_seconds"]
+
+    print("Simulation started...")
     while time.time() - start_time < duration:
         is_buy = random.choice([True, False])
         flow.register_trade(is_buy)
@@ -15,16 +22,20 @@ def simulate_trade_stream(flow: FlowReactor, duration=10):
         action = flow.get_signal()
         if action:
             print(f"[{time.strftime('%X')}] ACTION TRIGGERED: {action}")
-            # Cooldown to prevent repeated triggers
-            time.sleep(1)
-            # Reset the rolling window
+            time.sleep(cooldown)
             flow.buy_events.clear()
             flow.sell_events.clear()
 
-        time.sleep(random.uniform(0.1, 0.3))  # Simulate trade frequency
+        time.sleep(random.uniform(min_interval, max_interval))
+
+    print("Simulation complete.")
 
 if __name__ == "__main__":
     print("Starting TradeBot Flow Reactor...")
-    reactor = FlowReactor(buy_threshold=3, sell_threshold=3, window_seconds=1.0)
-    simulate_trade_stream(reactor, duration=30)
-    print("Simulation complete.")
+    config = load_config()
+    reactor = FlowReactor(
+        buy_threshold=config["buy_threshold"],
+        sell_threshold=config["sell_threshold"],
+        window_seconds=config["window_seconds"]
+    )
+    simulate_trade_stream(reactor, config)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,30 @@
+import time
+import random
+from core.flow_reactor import FlowReactor
+
+def simulate_trade_stream(flow: FlowReactor, duration=10):
+    """
+    Simulate a stream of random buy/sell trades over a fixed duration.
+    Replace this with real websocket data in future steps.
+    """
+    start_time = time.time()
+    while time.time() - start_time < duration:
+        is_buy = random.choice([True, False])
+        flow.register_trade(is_buy)
+
+        action = flow.get_signal()
+        if action:
+            print(f"[{time.strftime('%X')}] ACTION TRIGGERED: {action}")
+            # Cooldown to prevent repeated triggers
+            time.sleep(1)
+            # Reset the rolling window
+            flow.buy_events.clear()
+            flow.sell_events.clear()
+
+        time.sleep(random.uniform(0.1, 0.3))  # Simulate trade frequency
+
+if __name__ == "__main__":
+    print("Starting TradeBot Flow Reactor...")
+    reactor = FlowReactor(buy_threshold=3, sell_threshold=3, window_seconds=1.0)
+    simulate_trade_stream(reactor, duration=30)
+    print("Simulation complete.")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import time
 import random
 import json
 from core.flow_reactor import FlowReactor
+from utils.logger import log_action
 
 def load_config(path="config/config.json"):
     with open(path, "r") as f:
@@ -21,7 +22,7 @@ def simulate_trade_stream(flow, config):
 
         action = flow.get_signal()
         if action:
-            print(f"[{time.strftime('%X')}] ACTION TRIGGERED: {action}")
+            log_action(action)
             time.sleep(cooldown)
             flow.buy_events.clear()
             flow.sell_events.clear()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility helpers (logging, timing, IO, future API connectors)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,15 @@
+import os
+from datetime import datetime
+
+LOG_DIR = "logs"
+LOG_FILE = "trade_log.txt"
+
+os.makedirs(LOG_DIR, exist_ok=True)
+
+def log_action(action: str):
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    line = f"[{timestamp}] ACTION: {action}\n"
+    
+    print(line.strip())  # Still print to console
+    with open(os.path.join(LOG_DIR, LOG_FILE), "a") as f:
+        f.write(line)


### PR DESCRIPTION
This pull request refactors the original TradeBot to replace the static neural network demo with a real-time reactive order flow strategy, focusing on live trade event monitoring rather than predictive guesses.

Key improvements:

Added core/flow_reactor.py: monitors buy/sell trade frequency within a configurable rolling window and triggers immediate BUY/SELL signals when thresholds are crossed.

Rewrote main.py to simulate live trade data streams and execute the flow-based strategy with parameters fully loaded from config/config.json.

Added config/config.json to allow easy tuning of thresholds, cooldowns, and simulation parameters without changing code.

Introduced persistent logging of trade actions (utils/logger.py) to logs/trade_log.txt for audit and debugging purposes.

Added __init__.py files to core/ and utils/ for proper Python package structure.

Overall cleanup and modularization to make the bot extensible and ready for integration with real broker APIs or live data feeds.

This upgrade moves the bot from a static ML skeleton to a dynamic, reactive, threshold-driven trading system that’s more practical for real-world use and future enhancements.